### PR TITLE
Add readable endpoint to fetch a resource by ID

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -57,6 +57,8 @@ final class Client implements ClientInterface, LoggerAwareInterface
 
     private ?MapperBuilder $mapperBuilder = null;
 
+    private bool $debug = false;
+
     public function __construct(private readonly string $username, private readonly string $apiKey)
     {
         $this->logger = new NullLogger();
@@ -212,9 +214,17 @@ final class Client implements ClientInterface, LoggerAwareInterface
         $this->logger = $logger;
     }
 
+    public function setDebug(bool $debug): void
+    {
+        $this->debug = $debug;
+    }
+
     private function getBaseUri(): string
     {
-        return 'https://app.shipmondo.com/api/public/v3';
+        return sprintf(
+            'https://%s.shipmondo.com/api/public/v3',
+            $this->debug ? 'sandbox' : 'app',
+        );
     }
 
     private function getHttpClient(): HttpClientInterface

--- a/src/Client/Endpoint/Endpoint.php
+++ b/src/Client/Endpoint/Endpoint.php
@@ -19,7 +19,6 @@ use Webmozart\Assert\Assert;
 
 /**
  * @template TResponse of Response
- *
  * @implements EndpointInterface<TResponse>
  */
 abstract class Endpoint implements EndpointInterface, LoggerAwareInterface

--- a/src/Client/Endpoint/ReadableEndpointInterface.php
+++ b/src/Client/Endpoint/ReadableEndpointInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\Shipmondo\Client\Endpoint;
+
+use Setono\Shipmondo\Response\Response;
+
+/**
+ * @template TResponse of Response
+ */
+interface ReadableEndpointInterface
+{
+    /**
+     * @return TResponse
+     */
+    public function getById(int $id): Response;
+}

--- a/src/Client/Endpoint/ReadableEndpointTrait.php
+++ b/src/Client/Endpoint/ReadableEndpointTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\Shipmondo\Client\Endpoint;
+
+use Setono\Shipmondo\Response\Response;
+
+/**
+ * @mixin Endpoint
+ *
+ * @template TResponse of Response
+ */
+trait ReadableEndpointTrait
+{
+    /**
+     * @return TResponse
+     */
+    public function getById(int $id): Response
+    {
+        return $this
+            ->mapperBuilder
+            ->mapper()
+            ->map(
+                self::getResponseClass(),
+                $this->createSource(
+                    $this->client->get(sprintf('%s/%d', $this->endpoint, $id)),
+                ),
+            );
+    }
+}

--- a/src/Client/Endpoint/SalesOrdersEndpoint.php
+++ b/src/Client/Endpoint/SalesOrdersEndpoint.php
@@ -16,6 +16,11 @@ final class SalesOrdersEndpoint extends Endpoint implements SalesOrdersEndpointI
      */
     use CreatableEndpointTrait;
 
+    /**
+     * @use ReadableEndpointTrait<SalesOrderResponse>
+     */
+    use ReadableEndpointTrait;
+
     protected static function getResponseClass(): string
     {
         return SalesOrderResponse::class;

--- a/src/Client/Endpoint/SalesOrdersEndpointInterface.php
+++ b/src/Client/Endpoint/SalesOrdersEndpointInterface.php
@@ -9,7 +9,8 @@ use Setono\Shipmondo\Response\SalesOrders\SalesOrder as SalesOrderResponse;
 /**
  * @extends EndpointInterface<SalesOrderResponse>
  * @extends CreatableEndpointInterface<SalesOrderResponse>
+ * @extends ReadableEndpointInterface<SalesOrderResponse>
  */
-interface SalesOrdersEndpointInterface extends EndpointInterface, CreatableEndpointInterface
+interface SalesOrdersEndpointInterface extends EndpointInterface, CreatableEndpointInterface, ReadableEndpointInterface
 {
 }

--- a/src/Response/Collection.php
+++ b/src/Response/Collection.php
@@ -6,7 +6,6 @@ namespace Setono\Shipmondo\Response;
 
 /**
  * @template T
- *
  * @implements \IteratorAggregate<int, T>
  */
 final class Collection implements \Countable, \IteratorAggregate


### PR DESCRIPTION
## Summary
- Add a `Readable` endpoint capability following the existing trait-per-verb pattern (`Creatable`/`Deletable`): `ReadableEndpointInterface` + `ReadableEndpointTrait` expose `getById(int $id)` which does `GET /{endpoint}/{id}` and maps the response into the endpoint's DTO.
- Wire the capability into the sales orders endpoint, so `$client->salesOrders()->getById(123)` now works.
- Add `Client::setDebug(bool)` to switch the base URI between the production host (`app.shipmondo.com`) and the sandbox host (`sandbox.shipmondo.com`).
- Clean up `LiveClientTest`: replace the scratch webhook tests with a `getById` smoke test that asserts the returned sales order id, and drop the now-unused imports.

## Test plan
- `composer check-style` — clean
- `composer analyse` (Psalm) — no errors
- `composer phpunit` — 25 tests pass (the live `it_fetches_sales_order` test is gated behind `SHIPMONDO_LIVE`)