### PR TITLE
Fix Codecov upload (replace sunset bash uploader)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -188,9 +188,11 @@ jobs:
                 run: "vendor/bin/phpunit --coverage-clover=.build/logs/clover.xml"
 
             -   name: "Send code coverage report to Codecov.io"
-                env:
-                    CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
-                run: "bash <(curl -s https://codecov.io/bash)"
+                uses: "codecov/codecov-action@v5"
+                with:
+                    files: ".build/logs/clover.xml"
+                    token: "${{ secrets.CODECOV_TOKEN }}"
+                    fail_ci_if_error: false
 
     mutation-tests:
         name: "Mutation tests"


### PR DESCRIPTION
## Problem

The **Code Coverage** job uploads via the long-deprecated Codecov bash uploader:

```yaml
run: "bash <(curl -s https://codecov.io/bash)"
```

Codecov sunset `codecov.io/bash` years ago, so the report never reaches codecov.io. The job still goes green (the `curl` is effectively a no-op), which masked the failure — but **no `codecov/*` commit status is ever posted**, so the merge commit's status sits at `pending` and the coverage badge/report goes stale.

## Fix

Replace the bash step with the official **`codecov/codecov-action@v5`**, pointing at the existing clover report:

```yaml
-   name: "Send code coverage report to Codecov.io"
    uses: "codecov/codecov-action@v5"
    with:
        files: ".build/logs/clover.xml"
        token: "${{ secrets.CODECOV_TOKEN }}"
        fail_ci_if_error: false
```

Notes:
- The repo has **no `CODECOV_TOKEN` secret** (only `STRYKER_DASHBOARD_API_KEY`), so this relies on the action's **tokenless upload**, which works for public repos. The `token` input is kept so it's picked up automatically if a `CODECOV_TOKEN` secret is added later.
- `fail_ci_if_error: false` keeps the job non-blocking so a transient Codecov hiccup won't turn CI red.

## Verifying

This PR runs the `build` workflow (it triggers on `pull_request`), so the Code Coverage job will exercise the new uploader. After the run, the `codecov/project` + `codecov/patch` checks should appear on this PR — that's the confirmation the upload now works.

> Heads-up: the sibling `economic-php-sdk` has the same stale uploader and will need the same fix.