### PR TITLE
Raise test coverage (84% → 97% lines)

### DIFF
--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -7,6 +7,7 @@ namespace Setono\Shipmondo\Client;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Setono\Shipmondo\Exception\InternalServerErrorException;
+use Setono\Shipmondo\Exception\InvalidUrlException;
 use Setono\Shipmondo\Exception\MalformedResponseException;
 use Setono\Shipmondo\Exception\NotFoundException;
 use Setono\Shipmondo\Exception\ResponseAwareException;
@@ -106,5 +107,76 @@ final class ClientTest extends ShipmondoTestCase
         $this->expectException(MalformedResponseException::class);
 
         $this->client($http)->get('sales_orders/1');
+    }
+
+    #[Test]
+    public function it_throws_when_the_body_is_a_json_scalar_rather_than_an_array(): void
+    {
+        $http = (new ScriptedHttpClient())->on(self::BASE . '/sales_orders/1', '5');
+
+        $this->expectException(MalformedResponseException::class);
+
+        $this->client($http)->get('sales_orders/1');
+    }
+
+    #[Test]
+    public function it_refuses_to_send_credentials_to_a_foreign_host(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+
+        $this->client(new ScriptedHttpClient())->get('https://evil.example.com/sales_orders');
+    }
+
+    #[Test]
+    public function it_refuses_a_non_default_port_on_the_shipmondo_host(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+
+        $this->client(new ScriptedHttpClient())->get('https://sandbox.shipmondo.com:8443/api/public/v3/sales_orders');
+    }
+
+    #[Test]
+    public function it_refuses_query_parameters_combined_with_an_absolute_url(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+
+        $this->client(new ScriptedHttpClient())->get(self::BASE . '/sales_orders', ['page' => 2]);
+    }
+
+    #[Test]
+    public function it_allows_an_absolute_url_on_the_configured_host(): void
+    {
+        $url = self::BASE . '/payment_gateways';
+        $http = (new ScriptedHttpClient())->on($url, '[]');
+
+        $this->client($http)->get($url);
+
+        self::assertSame($url, (string) $http->sentRequests[0]->getUri());
+    }
+
+    #[Test]
+    public function the_last_request_and_response_are_null_before_any_call(): void
+    {
+        $client = $this->client(new ScriptedHttpClient());
+
+        self::assertNull($client->getLastRequest());
+        self::assertNull($client->getLastResponse());
+    }
+
+    #[Test]
+    public function it_exposes_the_last_request_and_response_after_a_call(): void
+    {
+        $http = (new ScriptedHttpClient())->on(self::BASE . '/payment_gateways', '[]');
+        $client = $this->client($http);
+
+        $client->get('payment_gateways');
+
+        $lastRequest = $client->getLastRequest();
+        self::assertNotNull($lastRequest);
+        self::assertSame('GET', $lastRequest->getMethod());
+
+        $lastResponse = $client->getLastResponse();
+        self::assertNotNull($lastResponse);
+        self::assertSame(200, $lastResponse->getStatusCode());
     }
 }

--- a/tests/Client/Endpoint/PickupPointsEndpointTest.php
+++ b/tests/Client/Endpoint/PickupPointsEndpointTest.php
@@ -49,4 +49,22 @@ final class PickupPointsEndpointTest extends ShipmondoTestCase
             (string) $http->sentRequests[0]->getUri(),
         );
     }
+
+    #[Test]
+    public function it_skips_non_array_rows_in_the_response(): void
+    {
+        $decoded = json_decode(self::fixture('pickup_points.json'), true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        $decoded[] = 'not-an-object'; // a stray scalar row the SDK must skip rather than map
+
+        $http = (new ScriptedHttpClient())->on(
+            self::BASE . '/pickup_points?carrier_code=gls&country_code=DK&zipcode=9000',
+            json_encode($decoded, \JSON_THROW_ON_ERROR),
+        );
+
+        $points = $this->client($http)->pickupPoints()->search(new PickupPointSearch('gls', 'DK', '9000'));
+
+        // Only the two valid pickup points come back; the scalar row was skipped.
+        self::assertCount(2, $points);
+    }
 }

--- a/tests/Client/Endpoint/SalesOrdersEndpointTest.php
+++ b/tests/Client/Endpoint/SalesOrdersEndpointTest.php
@@ -10,6 +10,8 @@ use Setono\Shipmondo\Request\SalesOrder\OrderLine;
 use Setono\Shipmondo\Request\SalesOrder\PaymentDetails;
 use Setono\Shipmondo\Request\SalesOrder\Recipient;
 use Setono\Shipmondo\Request\SalesOrder\SalesOrderRequest;
+use Setono\Shipmondo\Request\SalesOrder\Sender;
+use Setono\Shipmondo\Request\SalesOrder\ServicePoint;
 use Setono\Shipmondo\Response\SalesOrder\SalesOrder;
 use Setono\Shipmondo\ShipmondoTestCase;
 use Setono\Shipmondo\TestDouble\ScriptedHttpClient;
@@ -161,5 +163,30 @@ final class SalesOrdersEndpointTest extends ShipmondoTestCase
         self::assertSame('Widget', $orderLines[0]['item_name']);
         self::assertSame(3, $orderLines[0]['quantity']);
         self::assertSame('item', $orderLines[0]['line_type']);
+    }
+
+    #[Test]
+    public function it_serializes_the_sender_and_service_point(): void
+    {
+        $http = (new ScriptedHttpClient())->on(self::BASE . '/sales_orders', '{"id":1}');
+
+        $request = new SalesOrderRequest(orderId: '27000');
+        $request->sender = new Sender(name: 'ACME', address1: 'Depot 1', city: 'CPH', zipcode: '1000', countryCode: 'DK', vatId: 'DK999');
+        $request->servicePoint = new ServicePoint(id: '95115', name: 'Spar', zipcode: '9000', city: 'Aalborg', countryCode: 'DK', carrierCode: 'gls');
+
+        $this->client($http)->salesOrders()->create($request);
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $http->sentRequests[0]->getBody(), true, flags: \JSON_THROW_ON_ERROR);
+
+        // The sender uses `vat_id` (ship_to / bill_to use `vat_no` instead) and null fields are stripped.
+        self::assertSame(
+            ['name' => 'ACME', 'address1' => 'Depot 1', 'city' => 'CPH', 'zipcode' => '1000', 'country_code' => 'DK', 'vat_id' => 'DK999'],
+            $body['sender'],
+        );
+        self::assertSame(
+            ['id' => '95115', 'name' => 'Spar', 'zipcode' => '9000', 'city' => 'Aalborg', 'country_code' => 'DK', 'carrier_code' => 'gls'],
+            $body['service_point'],
+        );
     }
 }

--- a/tests/Client/Endpoint/WebhooksEndpointTest.php
+++ b/tests/Client/Endpoint/WebhooksEndpointTest.php
@@ -7,6 +7,7 @@ namespace Setono\Shipmondo\Client\Endpoint;
 use PHPUnit\Framework\Attributes\Test;
 use Setono\Shipmondo\Enum\WebhookAction;
 use Setono\Shipmondo\Enum\WebhookResourceName;
+use Setono\Shipmondo\Exception\MappingException;
 use Setono\Shipmondo\Request\Webhook\WebhookRequest;
 use Setono\Shipmondo\Response\Webhook\Webhook;
 use Setono\Shipmondo\ShipmondoTestCase;
@@ -78,5 +79,38 @@ final class WebhooksEndpointTest extends ShipmondoTestCase
 
         self::assertCount(1, $deleted);
         self::assertSame(self::BASE . '/webhooks/2', (string) $deleted[0]->getUri());
+    }
+
+    #[Test]
+    public function it_throws_a_mapping_exception_when_the_response_does_not_fit_the_dto(): void
+    {
+        // 200 OK with a JSON object that decodes fine but can't map to Webhook (required fields missing).
+        $http = (new ScriptedHttpClient())->on(self::BASE . '/webhooks', '{"foo":"bar"}');
+
+        $this->expectException(MappingException::class);
+
+        $this->client($http)->webhooks()->create(new WebhookRequest(
+            name: 'sdk-test',
+            endpoint: 'https://example.com',
+            key: 'a-sufficiently-long-webhook-signing-key',
+            action: WebhookAction::Create,
+            resourceName: WebhookResourceName::Shipments,
+        ));
+    }
+
+    #[Test]
+    public function it_skips_non_array_rows_in_a_page(): void
+    {
+        // The bare array mixes a valid webhook with a scalar row; the scalar must be skipped, not mapped.
+        $http = (new ScriptedHttpClient())->on(
+            self::BASE . '/webhooks?page=1&per_page=20',
+            '[{"id":1,"endpoint":"https://a","active":true,"name":"a","action":"create","resource_name":"Orders"},5]',
+            200,
+            ['X-Total-Pages' => '1'],
+        );
+
+        $page = $this->client($http)->webhooks()->getPage();
+
+        self::assertCount(1, iterator_to_array($page));
     }
 }

--- a/tests/Exception/ExceptionHierarchyTest.php
+++ b/tests/Exception/ExceptionHierarchyTest.php
@@ -38,6 +38,31 @@ final class ExceptionHierarchyTest extends TestCase
         self::assertNull($exception->getError());
     }
 
+    #[Test]
+    public function it_reads_the_error_lazily_from_the_response_when_no_body_is_supplied(): void
+    {
+        // No `body:` argument — getError() must fall back to reading the response stream itself.
+        $exception = new ValidationException(new Response(422, [], '{"error":"lazy"}'));
+
+        self::assertSame('lazy', $exception->getError());
+    }
+
+    #[Test]
+    public function it_returns_null_error_for_an_empty_response_body(): void
+    {
+        $exception = new NotFoundException(new Response(404));
+
+        self::assertNull($exception->getError());
+    }
+
+    #[Test]
+    public function it_returns_null_error_when_the_body_decodes_to_a_json_scalar(): void
+    {
+        $exception = new UnexpectedStatusCodeException(new Response(418, [], '5'));
+
+        self::assertNull($exception->getError());
+    }
+
     /**
      * @return \Generator<string, array{string, string}>
      */

--- a/tests/Request/CollectionRequestOptionsTest.php
+++ b/tests/Request/CollectionRequestOptionsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\Shipmondo\Request;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CollectionRequestOptionsTest extends TestCase
+{
+    #[Test]
+    public function it_builds_with_defaults_via_the_named_constructor(): void
+    {
+        $options = CollectionRequestOptions::new();
+
+        self::assertSame(1, $options->page);
+        self::assertSame(20, $options->perPage);
+        self::assertSame(['page' => 1, 'per_page' => 20], $options->toArray());
+    }
+
+    #[Test]
+    public function it_returns_new_instances_from_the_withers_and_leaves_the_original_untouched(): void
+    {
+        $base = CollectionRequestOptions::new();
+
+        $paged = $base->withPage(3);
+        $sized = $base->withPerPage(50);
+
+        self::assertSame(3, $paged->page);
+        self::assertSame(20, $paged->perPage);
+        self::assertSame(1, $sized->page);
+        self::assertSame(50, $sized->perPage);
+
+        // immutability: the original is untouched by either wither
+        self::assertSame(1, $base->page);
+        self::assertSame(20, $base->perPage);
+    }
+
+    #[Test]
+    #[DataProvider('outOfRangeValues')]
+    public function it_rejects_out_of_range_values(int $page, int $perPage): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new CollectionRequestOptions($page, $perPage);
+    }
+
+    /**
+     * @return \Generator<string, array{int, int}>
+     */
+    public static function outOfRangeValues(): \Generator
+    {
+        yield 'page below 1' => [0, 20];
+        yield 'per page below 1' => [1, 0];
+        yield 'per page above the 50 cap' => [1, 51];
+    }
+}

--- a/tests/Resolver/ShipmentTemplateResolverTest.php
+++ b/tests/Resolver/ShipmentTemplateResolverTest.php
@@ -67,6 +67,12 @@ final class ShipmentTemplateResolverTest extends TestCase
             ],
             new ShipmentTemplate(id: 2, name: 'GLS', sender: new Sender('DK'), receiver: new Receiver('DK'), parcels: [new Parcel(1, weight: 50), new Parcel(1, weight: 50)]),
         ];
+
+        yield 'resolvable with no parcels (country match is enough)' => [
+            new Shipment(shippingMethod: 'GLS', senderCountry: 'DK', receiverCountry: 'DK', weight: 100),
+            [new ShipmentTemplate(id: 1, name: 'GLS', sender: new Sender('DK'), receiver: new Receiver('DK'), parcels: [])],
+            new ShipmentTemplate(id: 1, name: 'GLS', sender: new Sender('DK'), receiver: new Receiver('DK'), parcels: []),
+        ];
     }
 
     /**


### PR DESCRIPTION
## What

Adds tests for previously-uncovered but **reachable** code paths. No source changes — tests only.

| Metric | Before | After |
|---|---|---|
| Lines | 84.26% (348/413) | **97.34% (402/413)** |
| Methods | 80.85% (76/94) | **94.68% (89/94)** |
| Classes | 62.50% (20/32) | **84.38% (27/32)** |

`Client` goes from 76% → **100%** lines/methods.

## Added coverage

- **`Client` URL guards** (`resolveUrl` + `parseStringPart`): refuse a foreign host, a non-default port, and query params combined with an absolute URL; allow an absolute URL on the configured host. These are the credential-leak guards, so they're worth pinning down.
- **`Client`**: a non-array JSON body → `MalformedResponseException`; `getLastRequest()` / `getLastResponse()` before and after a call.
- **`Endpoint::mapItem`**: a 2xx body that decodes but doesn't fit the DTO → `MappingException`.
- **`ResponseAwareException`**: lazy `getError()` that reads from the response stream when no body was pre-supplied, plus empty-body and JSON-scalar-body cases.
- **`CollectionEndpoint` / `PickupPointsEndpoint`**: non-array rows in a response are skipped, not mapped.
- **`CollectionRequestOptions`**: named constructor, withers (incl. immutability), and out-of-range validation.
- **SalesOrder write path**: serialize `Sender` (the `vat_id` quirk) and `ServicePoint`.
- **`ShipmentTemplateResolver`**: a template with no parcels matches on country alone.

## Remaining gaps (intentionally not chased)

The leftover uncovered lines are defensive branches not reachable through the public API — `Endpoint`'s null-response / null-request guards in the `MappingError` catch, `CollectionEndpoint`'s null-response header default, `ResourceEndpoint`'s no-id `getOne` path (no public caller), and `WebhookParser`'s `json_encode` re-encode catch (can't fail for a decoded JWT). Forcing those would mean mocking internals or artificial tests, so I left them.

## Verification

- PHPUnit: 95 tests / 226 assertions (3 live-API tests skipped)
- PHPStan **max**: clean
- ECS: clean