### PR TITLE
Add SalesOrdersEndpoint::delete()

### DIFF
--- a/src/Client/Endpoint/SalesOrdersEndpoint.php
+++ b/src/Client/Endpoint/SalesOrdersEndpoint.php
@@ -28,6 +28,14 @@ final class SalesOrdersEndpoint extends CollectionEndpoint
         return $this->createOne($request);
     }
 
+    /**
+     * Delete a sales order by id (`DELETE /sales_orders/{id}`).
+     */
+    public function delete(int $id): void
+    {
+        $this->client->delete('sales_orders', $id);
+    }
+
     protected static function getPath(): string
     {
         return 'sales_orders';

--- a/tests/Client/Endpoint/SalesOrdersEndpointTest.php
+++ b/tests/Client/Endpoint/SalesOrdersEndpointTest.php
@@ -166,6 +166,17 @@ final class SalesOrdersEndpointTest extends ShipmondoTestCase
     }
 
     #[Test]
+    public function it_deletes_a_sales_order_by_id(): void
+    {
+        $http = (new ScriptedHttpClient())->on(self::BASE . '/sales_orders/5', '');
+
+        $this->client($http)->salesOrders()->delete(5);
+
+        self::assertSame('DELETE', $http->sentRequests[0]->getMethod());
+        self::assertSame(self::BASE . '/sales_orders/5', (string) $http->sentRequests[0]->getUri());
+    }
+
+    #[Test]
     public function it_serializes_the_sender_and_service_point(): void
     {
         $http = (new ScriptedHttpClient())->on(self::BASE . '/sales_orders', '{"id":1}');


### PR DESCRIPTION
## What

Adds a delete operation to the sales-orders endpoint:

```php
$client->salesOrders()->delete(37707008); // DELETE /sales_orders/{id}
```

Mirrors the existing `WebhooksEndpoint::delete()` exactly — `delete(int $id): void`, routed through `Client::delete()` (which tolerates an empty response body). No interface changes needed (endpoints expose plain methods on the leaf).

## Tests

`SalesOrdersEndpointTest::it_deletes_a_sales_order_by_id` — asserts the `DELETE` method and `/sales_orders/5` URL via the scripted HTTP fake (same shape as the webhook delete test). No live test added — deleting against the real API is destructive.

## Verification

- PHPUnit: 107 tests / 250 assertions (3 live-API skipped)
- PHPStan **max**: clean
- ECS: clean